### PR TITLE
Downgrading redux-form to v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "react-redux": "4.3.0",
     "react-router": "^2.8.1",
     "redux": "^3.0.4",
-    "redux-form": "^7.1.1",
+    "redux-form": "5.2.4",
     "redux-promise": "^0.5.3"
   }
 }


### PR DESCRIPTION
Downgrading redux-form to v5, which supports mapStateToProps and mapDispatchToProps

https://redux-form.com/7.2.0/docs/migrationguide.md/